### PR TITLE
Add `--resolve-project-scripts` option

### DIFF
--- a/pyro/ProjectOptions.py
+++ b/pyro/ProjectOptions.py
@@ -50,6 +50,7 @@ class ProjectOptions:
     log_path: str = field(init=False, default_factory=str)
     create_project: bool = field(init=False, default_factory=bool)
     resolve_project: bool = field(init=False, default_factory=bool)
+    resolve_project_scripts: bool = field(init=False, default_factory=bool)
 
     def __post_init__(self) -> None:
         for attr_key, attr_value in self.__dict__.items():

--- a/pyro/__main__.py
+++ b/pyro/__main__.py
@@ -119,6 +119,9 @@ if __name__ == '__main__':
     _project_arguments.add_argument('--resolve-project',
                                     action='store_true',
                                     help='resolve variables and paths in project file')
+    _project_arguments.add_argument('--resolve-project-scripts',
+                                    action='store_true',
+                                    help='Print project info and resolved script paths as json')
 
     _program_arguments = _parser.add_argument_group('program arguments')
     _program_arguments.add_argument('--help', dest='show_help',


### PR DESCRIPTION
Dumps a json blob containing resolved project paths and resolved script paths

This is primarily for use with `papyrus-lang`; We want to start using pyro as a single source of truth for the project instead of trying to handle this ourselves. 

This is still a WIP as I refactor papyrus-lang to start using this, I'm just putting it here for feedback on the feature