### PR TITLE
Fix a few caprica issues

### DIFF
--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -10,6 +10,7 @@ on:
    - 'tools/**'
   branches:
    - master
+ workflow_dispatch:
 
 jobs:
  build:

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -18,15 +18,16 @@ jobs:
   runs-on: windows-latest
   
   steps:
-   - uses: actions/checkout@v1
+   - uses: actions/checkout@v4
    - name: Set up Visual Studio environment
      if: success()
-     uses: seanmiddleditch/gha-setup-vsdevenv@master
+     # temporarily using compnerd's fork. change back to seanmiddleditch's repo once the changes are merged
+     uses: compnerd/gha-setup-vsdevenv@main
    - name: Set up Python 3.10.4 (x64)
      if: success()
-     uses: actions/setup-python@v2
+     uses: actions/setup-python@v5
      with:
-      python-version: 3.10.4
+      python-version: '3.10.4'
       architecture: x64
    - name: Create virtual environment
      if: success()
@@ -39,7 +40,7 @@ jobs:
      run: python D:\a\pyro\pyro\build.py --no-zip
    - name: Upload artifact
      if: success()
-     uses: actions/upload-artifact@v1
+     uses: actions/upload-artifact@v4
      with:
       name: pyro-master-${{ github.event.repository.pushed_at }}
       path: D:\a\pyro\pyro\pyro.dist

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -19,6 +19,9 @@ jobs:
   
   steps:
    - uses: actions/checkout@v4
+   - name: Get current date
+     id: date
+     run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
    - name: Set up Visual Studio environment
      if: success()
      # temporarily using compnerd's fork. change back to seanmiddleditch's repo once the changes are merged
@@ -43,5 +46,5 @@ jobs:
      if: success()
      uses: actions/upload-artifact@v4
      with:
-      name: pyro-master-${{ github.event.repository.pushed_at }}
+      name: pyro-master-${{ steps.date.outputs.date }}
       path: D:\a\pyro\pyro\pyro.dist

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 __pycache__/
 bin/
 dev/
+env/
 pyro/dist/
 pyro/logs/
 pyro/out/

--- a/pyro/Application.py
+++ b/pyro/Application.py
@@ -83,8 +83,12 @@ class Application:
     @staticmethod
     def _validate_project_paths(ppj: PapyrusProject) -> None:
         compiler_path = ppj.get_compiler_path()
-        if not compiler_path or not os.path.isfile(compiler_path):
+        if not compiler_path:
             Application.log.error('Cannot proceed without compiler path')
+            sys.exit(1)
+            
+        if not os.path.isfile(compiler_path):
+            Application.log.error('Cannot proceed with invalid compiler path')
             sys.exit(1)
 
         flags_path = ppj.get_flags_path()

--- a/pyro/BuildFacade.py
+++ b/pyro/BuildFacade.py
@@ -104,26 +104,20 @@ class BuildFacade:
         if using_caprica or self.ppj.options.no_parallel or compile_data.command_count == 1:
             for command in commands:
                 BuildFacade.log.debug(f'Command: {command}')
-                if ProcessManager.run_compiler(command) == ProcessState.SUCCESS:
-                    compile_data.success_count += 1
+                ProcessManager.run_compiler(command, compile_data)
 
         elif compile_data.command_count > 0:
             multiprocessing.freeze_support()
             worker_limit = min(compile_data.command_count, self.ppj.options.worker_limit)
             with multiprocessing.Pool(processes=worker_limit,
                                       initializer=BuildFacade._limit_priority) as pool:
-                for state in pool.imap(ProcessManager.run_compiler, commands):
+                for state in pool.imap(ProcessManager.run_compiler, [commands, compile_data]):
                     if state == ProcessState.SUCCESS:
                         compile_data.success_count += 1
                 pool.close()
                 pool.join()
 
         compile_data.time.end_time = time.time()
-
-        # caprica success = all files compiled
-        if using_caprica and compile_data.success_count > 0:
-            compile_data.scripts_count = compile_data.command_count
-            compile_data.success_count = compile_data.command_count
 
     def try_anonymize(self) -> None:
         """Obfuscates identifying metadata in compiled scripts"""

--- a/pyro/BuildFacade.py
+++ b/pyro/BuildFacade.py
@@ -112,7 +112,7 @@ class BuildFacade:
             worker_limit = min(compile_data.command_count, self.ppj.options.worker_limit)
             with multiprocessing.Pool(processes=worker_limit,
                                       initializer=BuildFacade._limit_priority) as pool:
-                for state in pool.imap(ProcessManager.run_compiler, [commands, compile_data]):
+                for state in pool.starmap(ProcessManager.run_compiler, [(command, compile_data) for command in commands]):
                     if state == ProcessState.SUCCESS:
                         compile_data.success_count += 1
                 pool.close()

--- a/pyro/BuildFacade.py
+++ b/pyro/BuildFacade.py
@@ -123,7 +123,7 @@ class BuildFacade:
         # caprica success = all files compiled
         if using_caprica and compile_data.success_count > 0:
             compile_data.scripts_count = compile_data.command_count
-            compile_data.success_count = compile_data.success_count
+            compile_data.success_count = compile_data.command_count
 
     def try_anonymize(self) -> None:
         """Obfuscates identifying metadata in compiled scripts"""

--- a/pyro/BuildFacade.py
+++ b/pyro/BuildFacade.py
@@ -104,6 +104,7 @@ class BuildFacade:
         if using_caprica or self.ppj.options.no_parallel or compile_data.command_count == 1:
             for command in commands:
                 BuildFacade.log.debug(f'Command: {command}')
+                # caprica success logic is handled in the process manager
                 ProcessManager.run_compiler(command, compile_data)
 
         elif compile_data.command_count > 0:

--- a/pyro/PapyrusProject.py
+++ b/pyro/PapyrusProject.py
@@ -689,7 +689,8 @@ class PapyrusProject(ProjectBase):
 
             object_names = ';'.join(psc_paths.keys())
 
-            with open(self.get_compiler_config_path(), encoding='utf-8') as f:
+            # create file if it doesn't exist
+            with open(self.get_compiler_config_path(), mode="a+", encoding='utf-8') as f:
                 options = f.read().splitlines()
 
             # disable parallel compilation if the user overrides the default

--- a/pyro/PapyrusProject.py
+++ b/pyro/PapyrusProject.py
@@ -691,6 +691,7 @@ class PapyrusProject(ProjectBase):
 
             # create file if it doesn't exist
             with open(self.get_compiler_config_path(), mode="a+", encoding='utf-8') as f:
+                f.seek(0)
                 options = f.read().splitlines()
 
             # disable parallel compilation if the user overrides the default

--- a/pyro/PapyrusProject.py
+++ b/pyro/PapyrusProject.py
@@ -708,18 +708,21 @@ class PapyrusProject(ProjectBase):
                 f.seek(0)
                 options = f.read().splitlines()
 
-            # disable parallel compilation if the user overrides the default
-            if self.options.no_parallel and 'parallel-compile=1' in options:
-                for i, option in enumerate(options):
-                    if startswith(option, 'parallel-compile', ignorecase=True):
-                        options.pop(i)
-                        break
-            
-            # parallel compilation by default
-            if (not self.options.no_parallel 
-                and 'parallel-compile=0' not in options 
-                and 'parallel-compile=1' not in options):
-                options.append(f'parallel-compile=1\n')
+            # check and update config for parallel compilation
+            # and language extensions
+            for argument, argument_name, argument_value in \
+            ((self.options.no_parallel, "parallel-compile", 1), 
+             (self.options.no_caprica_language_extensions, "enable-language-extensions", 0)):
+                
+                # disable the option if the user overrides the default
+                if argument and f'{argument_name}={argument_value}' in options:
+                    options = [option for option in options 
+                            if not startswith(option, argument_name, ignorecase=True)]
+                
+                # but set it to argument_value if the user hasn't set it
+                if (not argument
+                    and not any(opt.startswith(argument_name) for opt in options)):
+                    options.append(f'{argument_name}={argument_value}\n')
 
             use_config_file_for_input_paths = False
 

--- a/pyro/PapyrusProject.py
+++ b/pyro/PapyrusProject.py
@@ -700,6 +700,12 @@ class PapyrusProject(ProjectBase):
                     if startswith(option, 'parallel-compile', ignorecase=True):
                         options.pop(i)
                         break
+            
+            # parallel compilation by default
+            if (not self.options.no_parallel 
+                and 'parallel-compile=0' not in options 
+                and 'parallel-compile=1' not in options):
+                options.append(f'parallel-compile=1\n')
 
             use_config_file_for_input_paths = False
 

--- a/pyro/Performance/CompileData.py
+++ b/pyro/Performance/CompileData.py
@@ -32,7 +32,7 @@ class CompileData:
 class CompileDataCaprica(CompileData):
     @property
     def failed_count(self) -> int:
-        return 1 if self.success_count == 0 else 0
+        return 1 if (self.success_count == 0 and self.command_count > 0) else 0
 
     def to_string(self) -> str:
         raw_time = '{0:.3f}s'.format(self.time.value())

--- a/pyro/Performance/CompileData.py
+++ b/pyro/Performance/CompileData.py
@@ -30,9 +30,6 @@ class CompileData:
 
 @dataclass
 class CompileDataCaprica(CompileData):
-    # @property
-    # def failed_count(self) -> int:
-    #     return 1 if (self.success_count == 0 and self.command_count > 0) else 0
 
     def to_string(self) -> str:
         raw_time = '{0:.3f}s'.format(self.time.value())

--- a/pyro/Performance/CompileData.py
+++ b/pyro/Performance/CompileData.py
@@ -30,9 +30,9 @@ class CompileData:
 
 @dataclass
 class CompileDataCaprica(CompileData):
-    @property
-    def failed_count(self) -> int:
-        return 1 if (self.success_count == 0 and self.command_count > 0) else 0
+    # @property
+    # def failed_count(self) -> int:
+    #     return 1 if (self.success_count == 0 and self.command_count > 0) else 0
 
     def to_string(self) -> str:
         raw_time = '{0:.3f}s'.format(self.time.value())

--- a/pyro/ProcessManager.py
+++ b/pyro/ProcessManager.py
@@ -171,7 +171,8 @@ class ProcessManager:
             'Failed',
             'No output',
             'Papyrus',
-            'Starting'
+            'Starting',
+            'Adding'
         )
 
         # PapyrusCompiler's error structure:
@@ -183,16 +184,17 @@ class ProcessManager:
         # Caprica's error structure:
         # filename      [example.psc ]  ([^\(]*\.psc)\s+
         # location      [(69, 4:20)]    (\(-?\d*\.?\d+, -?\d*\.?\d+:-?\d*\.?\d+\))
-        # error/warning [: Warning 1: ] :\s+(.*):\s+
+        # error/warning [: Warning 1: ] :\s+([\w\s]+):\s+
         # error message [bad molly.]    ((?:[^p]|p(?:[^s]|$)|ps(?:[^c]|$))*[^\w\s\\/])(?=$|(?:.+psc))
         # sometimes, caprica sends two error messages in one line
         # The above regex uses the psc in the file extension to find where to stop
-        line_error_caprica = re.compile(r'([^\(]*\.psc)\s+(\(-?\d*\.?\d+, -?\d*\.?\d+:-?\d*\.?\d+\)):\s+(\w*):\s+((?:[^p]|p(?:[^s]|$)|ps(?:[^c]|$))*[^\w\s\\/])(?=$|(?:.+psc))')
+        line_error_caprica = re.compile(r'([^\(]*\.psc)\s+(\(-?\d*\.?\d+, -?\d*\.?\d+:-?\d*\.?\d+\)):\s+([\w\s]+):\s+((?:[^p]|p(?:[^s]|$)|ps(?:[^c]|$))*[^\w\s\\/])(?=$|(?:.+psc))')
         
         line_error = line_error_caprica if using_caprica else line_error_papyrus
 
         compilation_count_caprica = re.compile(r'Compiling (\d+)')
-
+        compilation_count = 0
+        
         error_count = 0
         errors = set()
 

--- a/pyro/ProjectOptions.py
+++ b/pyro/ProjectOptions.py
@@ -32,6 +32,7 @@ class ProjectOptions:
     flags_path: str = field(init=False, default_factory=str)
     output_path: str = field(init=False, default_factory=str)
     compiler_config_path: str = field(init=False, default_factory=str)
+    no_caprica_language_extensions: bool=field(init=True, default_factory=bool)
 
     # bsarch arguments
     bsarch_path: str = field(init=False, default_factory=str)

--- a/pyro/ProjectOptions.py
+++ b/pyro/ProjectOptions.py
@@ -31,6 +31,7 @@ class ProjectOptions:
     compiler_path: str = field(init=False, default_factory=str)
     flags_path: str = field(init=False, default_factory=str)
     output_path: str = field(init=False, default_factory=str)
+    compiler_config_path: str = field(init=False, default_factory=str)
 
     # bsarch arguments
     bsarch_path: str = field(init=False, default_factory=str)

--- a/pyro/Remotes/RemoteBase.py
+++ b/pyro/Remotes/RemoteBase.py
@@ -3,6 +3,7 @@ import os
 from typing import Generator, Optional
 from urllib.error import HTTPError
 from urllib.parse import urlparse
+from urllib.parse import unquote
 
 from pyro.Comparators import startswith
 from pyro.Remotes.RemoteUri import RemoteUri
@@ -30,23 +31,21 @@ class RemoteBase:
         """
         parsed_url = urlparse(url)
 
-        netloc = parsed_url.netloc
+        netloc = unquote(parsed_url.netloc)
+        url_path_parts = parsed_url.path.split('/')
+        url_path_parts.pop(0) if not url_path_parts[0] else None  # pop empty space
+        
+        # unquote url
+        url_path_parts = [unquote(part) for part in url_path_parts]
 
         if netloc in self.url_patterns:
-            url_path_parts = parsed_url.path.split('/')
-            url_path_parts.pop(0) if not url_path_parts[0] else None  # pop empty space
-
             if netloc == 'github.com' and len(url_path_parts) == 2:
                 return os.sep.join(url_path_parts)
 
             for i in self.url_patterns[netloc]:
                 url_path_parts.pop(i)
 
-            url_path = os.sep.join(url_path_parts)
-        else:
-            url_path_parts = parsed_url.path.split('/')
-            url_path_parts.pop(0) if not url_path_parts[0] else None  # pop empty space
-            url_path = os.sep.join(url_path_parts)
+        url_path = os.sep.join(url_path_parts)
 
         return url_path
 
@@ -105,11 +104,11 @@ class RemoteBase:
                 request_url = url
 
         if 'api/v1' not in path:
-            result.owner = url_path_parts[0]
-            result.repo = url_path_parts[1]
+            result.owner = unquote(url_path_parts[0])
+            result.repo = unquote(url_path_parts[1])
         else:
-            result.owner = url_path_parts[3]
-            result.repo = url_path_parts[4]
+            result.owner = unquote(url_path_parts[3])
+            result.repo = unquote(url_path_parts[4])
 
         result.url = request_url
 

--- a/pyro/__main__.py
+++ b/pyro/__main__.py
@@ -63,6 +63,10 @@ if __name__ == '__main__':
                                      action='store', type=str,
                                      help='relative or absolute path to output folder\n'
                                           '(if relative, must be relative to project)')
+    _compiler_arguments.add_argument('--caprica-language-extensions',
+                                     action='store_true', default=False,
+                                     help='enable Caprica language extensions\n'
+                                          '(only works if using Caprica as your compiler)')
 
     _game_arguments = _parser.add_argument_group('game arguments')
     _game_arguments.add_argument('-g', '--game-type',


### PR DESCRIPTION
Just a few minor bugs I've found. I've tested this and believe it's ready to merge.

Here's what this PR does:

- Brings build script out of deprecated versions
- Doesn't crash when using caprica (since caprica_config_path wasn't defined)
- Doesn't crash if no default caprica config is found
- Doesn't throw an error if it doesn't build any scripts
- Properly handles caprica warnings and errors